### PR TITLE
Add basic NPC dialogue and multiplayer support

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -248,7 +248,11 @@ class Game {
     hideBattleModal() {
         document.getElementById('battle-modal').classList.add('hidden');
     }
-    
+
+    showDialogue(message) {
+        alert(message);
+    }
+
     toggleMissionsModal() {
         const modal = document.getElementById('missions-modal');
         if (modal.classList.contains('hidden')) {
@@ -353,7 +357,11 @@ class Game {
         this.socket.on('npc:respawned', (data) => {
             this.handleNpcRespawned(data);
         });
-        
+
+        this.socket.on('npc:dialogue', (data) => {
+            this.showDialogue(data.dialogue);
+        });
+
         this.socket.on('error', (data) => {
             alert(`Erro: ${data.message}`);
         });


### PR DESCRIPTION
## Summary
- Track players server-side and broadcast movements for simple multiplayer
- Send NPC dialogues and basic math battles when interacting
- Display server-sent dialogue messages on the client

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0ef1fc71c83308f6bf5eccb358c48