### PR TITLE
Add NPC life bars during battles

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -139,3 +139,39 @@ button:hover {
     text-align: center;
     font-family: monospace;
 }
+
+/* Barras de HP na batalha */
+.hp-bar-container {
+    width: 100%;
+    height: 20px;
+    background-color: #7f8c8d;
+    border: 1px solid #34495e;
+    border-radius: 4px;
+    margin: 10px 0;
+    position: relative;
+}
+
+.hp-bar-fill {
+    height: 100%;
+    width: 100%;
+    border-radius: 4px;
+}
+
+.hp-bar-fill.npc {
+    background-color: #e74c3c;
+}
+
+.hp-bar-fill.player {
+    background-color: #2ecc71;
+}
+
+.hp-bar-text {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    line-height: 20px;
+    font-size: 12px;
+    color: #ecf0f1;
+}

--- a/public/game.js
+++ b/public/game.js
@@ -235,18 +235,26 @@ class Game {
         document.getElementById('login-modal').classList.add('hidden');
     }
     
-    showBattleModal(npcName, question) {
+    showBattleModal(npcName, question, playerHp, npcHp) {
         document.getElementById('battle-npc-name').textContent = `Desafio de ${npcName}`;
         document.getElementById('battle-question').textContent = question;
         document.getElementById('battle-answer').value = '';
         document.getElementById('battle-result').textContent = '';
         document.getElementById('battle-result').className = '';
         document.getElementById('battle-modal').classList.remove('hidden');
+
+        // Inicializar HPs
+        if (!this.currentBattle) this.currentBattle = {};
+        this.currentBattle.playerHp = playerHp;
+        this.currentBattle.npcHp = npcHp;
+        this.updateBattleHpUI();
+
         document.getElementById('battle-answer').focus();
     }
     
     hideBattleModal() {
         document.getElementById('battle-modal').classList.add('hidden');
+        this.currentBattle = null;
     }
     
     toggleMissionsModal() {
@@ -417,8 +425,10 @@ class Game {
     }
     
     handleBattleStart(data) {
-        this.showBattleModal(data.npcName, data.question);
+        data.playerHp = this.player ? this.player.hp : 0;
+        data.npcHp = 100;
         this.currentBattle = data;
+        this.showBattleModal(data.npcName, data.question, data.playerHp, data.npcHp);
     }
     
     handleBattleResult(data) {
@@ -449,7 +459,14 @@ class Game {
                     alert(`Parabéns! Você subiu para o nível ${newLevel}!`);
                 }
             }
-            
+
+            // Atualizar HPs da batalha
+            if (this.currentBattle) {
+                this.currentBattle.playerHp = this.player.hp;
+                this.currentBattle.npcHp = data.npcHp;
+                this.updateBattleHpUI();
+            }
+
             if (data.npcDefeated) {
                 setTimeout(() => {
                     this.hideBattleModal();
@@ -549,6 +566,24 @@ class Game {
         document.getElementById('player-wins').textContent = this.player.wins;
         document.getElementById('player-losses').textContent = this.player.losses;
         document.getElementById('player-coins').textContent = this.player.coins;
+    }
+
+    updateBattleHpUI() {
+        const npcBar = document.getElementById('battle-npc-hp');
+        const npcText = document.getElementById('battle-npc-hp-text');
+        const playerBar = document.getElementById('battle-player-hp');
+        const playerText = document.getElementById('battle-player-hp-text');
+
+        if (!npcBar || !playerBar || !this.currentBattle) return;
+
+        const npcPercent = (this.currentBattle.npcHp / 100) * 100;
+        npcBar.style.width = `${npcPercent}%`;
+        npcText.textContent = `${this.currentBattle.npcHp}/100`;
+
+        const playerMax = this.player ? this.player.max_hp : 100;
+        const playerPercent = (this.currentBattle.playerHp / playerMax) * 100;
+        playerBar.style.width = `${playerPercent}%`;
+        playerText.textContent = `${this.currentBattle.playerHp}/${playerMax}`;
     }
     
     interact() {

--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,16 @@
                 <h2>Batalha Matemática</h2>
                 <p id="battle-npc-name"></p>
                 <div id="battle-question"></div>
+                <div id="battle-hp-bars">
+                    <div class="hp-bar-container">
+                        <div id="battle-npc-hp" class="hp-bar-fill npc"></div>
+                        <span id="battle-npc-hp-text" class="hp-bar-text"></span>
+                    </div>
+                    <div class="hp-bar-container">
+                        <div id="battle-player-hp" class="hp-bar-fill player"></div>
+                        <span id="battle-player-hp-text" class="hp-bar-text"></span>
+                    </div>
+                </div>
                 <input type="text" id="battle-answer" placeholder="Sua resposta">
                 <button id="btn-battle-submit">Responder</button>
                 <div id="battle-result"></div>


### PR DESCRIPTION
## Summary
- Display NPC and player HP bars in battle modal
- Update battle logic to track and render HP values
- Style new HP bars

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b172cdbdf483309faea03e79d6068a